### PR TITLE
chore: remove redundant useVisibleTask

### DIFF
--- a/packages/template/src/components/Highlight/Highlight.tsx
+++ b/packages/template/src/components/Highlight/Highlight.tsx
@@ -1,12 +1,5 @@
 import type { ClassList, PropsOf } from "@builder.io/qwik";
-import {
-  $,
-  component$,
-  useSignal,
-  useTask$,
-  useVisibleTask$,
-} from "@builder.io/qwik";
-import { isDev } from "@builder.io/qwik/build";
+import { $, component$, useSignal, useTask$ } from "@builder.io/qwik";
 import { getHighlighterCore } from "shiki";
 import css from "shiki/langs/css.mjs";
 import html from "shiki/langs/html.mjs";
@@ -64,17 +57,7 @@ export const Highlight = component$(
 
     useTask$(async ({ track }) => {
       track(() => code);
-      if (!isDev) {
-        await addShiki$();
-      }
-    });
-
-    // eslint-disable-next-line qwik/no-use-visible-task
-    useVisibleTask$(async ({ track }) => {
-      track(() => code);
-      if (isDev) {
-        await addShiki$();
-      }
+      await addShiki$();
     });
 
     return (


### PR DESCRIPTION
I could be wrong, but I don't see a point in distinguishing between dev and production when it's calling the same function in both instances. No loss seems to come from using a the task over the visibleTask.